### PR TITLE
Harden plugin capability boundaries

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,23 @@
+# Security hardening notes
+
+## Plugin global API
+
+`window.sb` is only a registration facade: `version`, `state`, and
+`plugins.register/ready`. Privileged APIs are passed to plugin `init()` through
+`PluginContext.sb` after manifest validation and capability intersection.
+
+## Relay authentication
+
+The relay supports an optional `__SB_RELAY_TOKEN__` injected by the native
+loader into both MainShell and SharedJSContext. When present, SharedJSContext
+ignores command messages that do not carry this token.
+
+Native loader requirement:
+
+1. Generate a fresh high-entropy token per SteamBooster process/session.
+2. Inject it before the framework runs in every context that participates in
+   `BroadcastChannel('sb_cmd')`.
+3. Do not expose it through plugin manifests, config, logs, or public APIs.
+
+Without the native token, the framework keeps backward-compatible behavior.
+This mode is not a complete security boundary for untrusted plugins.

--- a/src/api/api-types.ts
+++ b/src/api/api-types.ts
@@ -586,6 +586,16 @@ export interface PluginsApi {
   ready(): Promise<void>;
 }
 
+/**
+ * Minimal global exposed to plugin bundles before their gated PluginContext
+ * exists. Privileged modules are intentionally absent from window.sb.
+ */
+export interface PluginRegistrationApi {
+  readonly version: string;
+  readonly state: 'loading' | 'ready' | 'disabled';
+  readonly plugins: PluginsApi;
+}
+
 
 export interface AppApi {
   /** Persistent per-install token (UUID), or undefined if unavailable. */

--- a/src/api/external-window.ts
+++ b/src/api/external-window.ts
@@ -1,4 +1,5 @@
 import type { OpenExternalWindowHandle, OpenExternalWindowOptions } from './api-types';
+import { type RelayAuthToken, withRelayAuth } from '../relay/auth';
 
 const ID_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 const TITLE_MIN = 1;
@@ -21,6 +22,7 @@ export function _internal_bcRequest(
   bc: { postMessage: (m: any) => void },
   msg: { kind: string; [k: string]: unknown },
   timeoutMsOverride?: number,  // injectable for tests; default REQUEST_TIMEOUT_MS
+  relayAuthToken?: RelayAuthToken,
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     if (nextRequestId >= REQUEST_ID_MAX) {
@@ -39,7 +41,7 @@ export function _internal_bcRequest(
       resolve: (v) => { clearTimeout(timer); resolve(v); },
       reject:  (e) => { clearTimeout(timer); reject(e); },
     });
-    bc.postMessage({ ...msg, requestId });
+    bc.postMessage(withRelayAuth({ ...msg, requestId }, relayAuthToken));
   });
 }
 
@@ -99,6 +101,7 @@ export function validateUrl(url: string, label: string): void {
 
 export interface ExternalWindowApiDeps {
   bcChannel: BroadcastChannel | { postMessage: (m: any) => void; addEventListener: (t: string, cb: any) => void };
+  relayAuthToken?: RelayAuthToken;
 }
 
 export function createExternalWindowApi(deps: ExternalWindowApiDeps) {
@@ -113,14 +116,14 @@ export function createExternalWindowApi(deps: ExternalWindowApiDeps) {
         url: opts.url,
         ...(opts.title !== undefined ? { title: opts.title } : {}),
         ...(opts.taskbarTitle !== undefined ? { taskbarTitle: opts.taskbarTitle } : {}),
-      });
+      }, undefined, deps.relayAuthToken);
       if (!reply.ok) throw new Error(`openExternalWindow: ${reply.error ?? 'unknown error'}`);
-      return makeHandle(opts.id, deps.bcChannel as any);
+      return makeHandle(opts.id, deps.bcChannel as any, deps.relayAuthToken);
     },
   };
 }
 
-function makeHandle(id: string, bc: any): OpenExternalWindowHandle {
+function makeHandle(id: string, bc: any, relayAuthToken?: RelayAuthToken): OpenExternalWindowHandle {
   let closed = false;
   const closeCallbacks: Array<() => void> = [];
 
@@ -148,11 +151,11 @@ function makeHandle(id: string, bc: any): OpenExternalWindowHandle {
     setUrl(url: string) {
       if (closed) return;
       validateUrl(url, 'setUrl(url)');
-      bc.postMessage({ kind: 'external-window-set-url', id, url });
+      bc.postMessage(withRelayAuth({ kind: 'external-window-set-url', id, url }, relayAuthToken));
     },
     close() {
       if (closed) return;
-      bc.postMessage({ kind: 'external-window-close', id });
+      bc.postMessage(withRelayAuth({ kind: 'external-window-close', id }, relayAuthToken));
     },
     on(event: 'close', cb: () => void): () => void {
       if (event !== 'close') throw new Error(`unknown event: ${event}`);

--- a/src/api/keys.ts
+++ b/src/api/keys.ts
@@ -1,6 +1,7 @@
 import type { KeysApi, ActivateOutcome } from './api-types';
 import type { Registry } from '../registry';
 import { RELAY_CHANNEL } from '../relay/protocol';
+import { readRelayAuthToken, withRelayAuth } from '../relay/auth';
 
 const KEYS_REQUEST_ID_BASE = 300_000;
 
@@ -22,6 +23,7 @@ export class KeyActivationTransportError extends Error {
 
 export function makeKeysApi(registry: Registry): KeysApi {
   const bc = new BroadcastChannel(RELAY_CHANNEL);
+  const relayAuthToken = readRelayAuthToken();
   let nextRequestId = KEYS_REQUEST_ID_BASE;
   const pending = new Map<number, { reject: (e: Error) => void; cleanup: () => void }>();
 
@@ -56,7 +58,7 @@ export function makeKeysApi(registry: Registry): KeysApi {
         };
         pending.set(requestId, { reject, cleanup });
         bc.addEventListener('message', handler);
-        bc.postMessage({ kind: 'activate-product-key', requestId, key: productKey });
+        bc.postMessage(withRelayAuth({ kind: 'activate-product-key', requestId, key: productKey }, relayAuthToken));
       });
     },
   };

--- a/src/api/steam.ts
+++ b/src/api/steam.ts
@@ -4,6 +4,10 @@ import type { Bridge } from '../bridge';
 import { RELAY_CHANNEL } from '../relay/protocol';
 import { deriveCurrency, parseBalanceNumber } from '../steam-internals/currency-map';
 import { readCurrentSteamId64FromStoreGlobal } from '../steam-internals/steam-id';
+import { isUrlSafeForNavigation, safeHostForLog } from '../navigation-safety';
+import { readRelayAuthToken, withRelayAuth } from '../relay/auth';
+
+export { isUrlSafeForNavigation } from '../navigation-safety';
 
 // Window.SteamClient shape is declared in relay/shared-context.ts (merged interface).
 
@@ -32,55 +36,6 @@ function getStoreCountrySteamIdWaitMs(): number {
 }
 
 
-// Basic URL safety gate (NOT a host allow-list). The legitimate redirect
-// flow goes:
-//   booster-checkout → /api/balance/add (steambalance.cc) → JSON {redirectUrl: ...}
-//   → openUrl(redirectUrl) → MainWindowBrowserManager.LoadURL
-// where redirectUrl points at a payment processor (Tinkoff / СБП / etc.) —
-// host known only at runtime. The previous host allow-list (steambalance.cc
-// only) blocked every real payment redirect with `host not allowed: <safeHost>`,
-// which surfaced to the user as "Pay button does nothing" (popup just
-// console.error-ed and reset). The reference implementation
-// (C:/Users/Matrix/Desktop/sb_booster-main/scripts/popup_manager_native.js)
-// calls LoadURL on whatever URL the popup posts, with no validation at all.
-//
-// Trust model: redirectUrl originates from steambalance.cc's own API
-// response (HTTPS-fetched by the popup). The framework does NOT receive
-// arbitrary URLs from untrusted sources. We do reject obvious
-// foot-gun URL shapes (non-https, credential injection via userinfo,
-// non-standard ports) since those have no legitimate use in a payment
-// redirect and would either fail in CEF or carry exfil risk.
-//
-// Exported for unit testing — internal helper, not part of the public SbApi.
-/** @internal */
-export function isUrlSafeForNavigation(url: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== 'https:') return false;
-  // No userinfo: `https://attacker:pass@example.com/x` parses with
-  // host=example.com but routes credentials. Reject.
-  if (parsed.username !== '' || parsed.password !== '') return false;
-  // Empty port → default 443 only. Reject explicit ports (8080, 8443, etc).
-  if (parsed.port !== '') return false;
-  return true;
-}
-
-// Hostname-only for error messages — never includes port or query string,
-// so it's safe to log even if the input URL carries a session token in
-// userinfo or query (isHostAllowed already rejects such URLs, but safety
-// is layered).
-function safeHostForLog(url: string): string {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return '<malformed>';
-  }
-}
-
 interface SnapshotPayload {
   accountName: string;
   personaName?: string;
@@ -92,6 +47,10 @@ interface SnapshotPayload {
 
 export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
   const bc = new BroadcastChannel(RELAY_CHANNEL);
+  const relayAuthToken = readRelayAuthToken();
+  const postRelay = (msg: Record<string, unknown>): void => {
+    bc.postMessage(withRelayAuth(msg, relayAuthToken));
+  };
   let nextRequestId = STEAM_REQUEST_ID_BASE;
   // Heterogeneous resolve type: navigate resolves void. Each call site owns
   // its narrow signature via the closure that wraps `pending.set(...)`.
@@ -135,7 +94,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
         resolve({ email: m.email, emailValidated: m.emailValidated });
       };
       bc.addEventListener('message', handler);
-      bc.postMessage({ kind: 'get-user-account-settings', requestId });
+      postRelay({ kind: 'get-user-account-settings', requestId });
     });
   }
 
@@ -154,7 +113,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
         resolve(m.value);
       };
       bc.addEventListener('message', handler);
-      bc.postMessage({ kind: 'get-user-country', requestId });
+      postRelay({ kind: 'get-user-country', requestId });
     });
   }
 
@@ -173,7 +132,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
         resolve(m.value);
       };
       bc.addEventListener('message', handler);
-      bc.postMessage({ kind: 'get-user-language', requestId });
+      postRelay({ kind: 'get-user-language', requestId });
     });
   }
 
@@ -192,7 +151,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
         resolve(m.value);
       };
       bc.addEventListener('message', handler);
-      bc.postMessage({ kind: 'get-machine-id', requestId });
+      postRelay({ kind: 'get-machine-id', requestId });
     });
   }
 
@@ -290,7 +249,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
   // the current user's core fields. If the relay isn't up yet, the request
   // is silently dropped and the framework stays at null until relay boots and
   // broadcasts proactively.
-  bc.postMessage({ kind: 'request-snapshot' });
+  postRelay({ kind: 'request-snapshot' });
 
   async function resolveCurrentSteamId(): Promise<string | undefined> {
     if (cachedUser?.steamId) return cachedUser.steamId;
@@ -334,7 +293,7 @@ export function makeSteamApi(registry: Registry, bridge: Bridge): SteamApi {
           resolve: () => { clearTimeout(timer); resolve(); },
           reject: (e: Error) => { clearTimeout(timer); reject(e); },
         });
-        bc.postMessage({ kind: 'navigate', requestId, url });
+        postRelay({ kind: 'navigate', requestId, url });
       });
     },
 

--- a/src/api/ui.ts
+++ b/src/api/ui.ts
@@ -19,7 +19,8 @@ import {
 import { nativeWarn } from '../native-warn';
 import { ensureToolbarStyles } from './ui-toolbar-styles';
 import { wireTooltip } from './ui-tooltip';
-import { isUrlSafeForNavigation } from './steam';
+import { isUrlSafeForNavigation } from '../navigation-safety';
+import { readRelayAuthToken, withRelayAuth } from '../relay/auth';
 
 const ATTACH_TIMEOUT_MS = 5000;
 // Cap our requestId space so it never collides with steam.ts (which starts
@@ -38,6 +39,10 @@ interface PopupListenerSets {
 
 export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
   const bc = new BroadcastChannel(RELAY_CHANNEL);
+  const relayAuthToken = readRelayAuthToken();
+  const postRelay = (msg: Record<string, unknown>): void => {
+    bc.postMessage(withRelayAuth(msg, relayAuthToken));
+  };
   // Register the BC instance with the registry so on framework re-injection
   // (lifecycle.rollbackAll), this BC is closed and its listeners released.
   // Without this hook, every re-inject leaks a live message subscription.
@@ -146,7 +151,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
     },
   });
 
-  const externalWindowApi = createExternalWindowApi({ bcChannel: bc });
+  const externalWindowApi = createExternalWindowApi({ bcChannel: bc, relayAuthToken });
 
   function attachRequest<T>(req: Record<string, unknown>): Promise<T> {
     if (nextRequestId > UI_REQUEST_ID_MAX) {
@@ -176,7 +181,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
           reject(e);
         },
       });
-      bc.postMessage(message);
+      postRelay(message);
     });
   }
 
@@ -386,7 +391,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
             // Fire-and-forget: relay's teardown also Closes() the popup, but
             // calling out here on framework rollback ensures no orphan even
             // if relay hasn't started yet (race on injection ordering).
-            try { bc.postMessage({ kind: 'popup-destroy', popupId: opts.id }); } catch { /* */ }
+            try { postRelay({ kind: 'popup-destroy', popupId: opts.id }); } catch { /* */ }
             popupListeners.delete(opts.id);
           },
         }),
@@ -432,16 +437,16 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
         width:  widthClamped,
         height: heightClamped,
         show(at): void {
-          bc.postMessage({ kind: 'popup-show', popupId: opts.id, x: at.x, y: at.y });
+          postRelay({ kind: 'popup-show', popupId: opts.id, x: at.x, y: at.y });
         },
         hide(): void {
-          bc.postMessage({ kind: 'popup-hide', popupId: opts.id });
+          postRelay({ kind: 'popup-hide', popupId: opts.id });
         },
         toggle(at): void {
-          bc.postMessage({ kind: 'popup-toggle', popupId: opts.id, x: at.x, y: at.y });
+          postRelay({ kind: 'popup-toggle', popupId: opts.id, x: at.x, y: at.y });
         },
         postMessage(data): void {
-          bc.postMessage({ kind: 'popup-postMessage', popupId: opts.id, data });
+          postRelay({ kind: 'popup-postMessage', popupId: opts.id, data });
         },
         on(event, cb): () => void {
           const set = sets[event];
@@ -452,7 +457,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
           return visible;
         },
         destroy(): void {
-          bc.postMessage({ kind: 'popup-destroy', popupId: opts.id });
+          postRelay({ kind: 'popup-destroy', popupId: opts.id });
           popupListeners.delete(opts.id);
           registry.remove(sets.undoId);
         },
@@ -508,7 +513,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
           // will close the popup window separately, but issuing window-close
           // here ensures no orphan even if relay hasn't started yet (race on
           // injection ordering).
-          try { bc.postMessage({ kind: 'window-close', windowId: opts.id }); } catch { /* */ }
+          try { postRelay({ kind: 'window-close', windowId: opts.id }); } catch { /* */ }
           windowListeners.delete(opts.id);
         },
       });
@@ -578,15 +583,15 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
         height: effH,
         show(): void {
           if (closed) return;
-          bc.postMessage({ kind: 'window-show', windowId: opts.id });
+          postRelay({ kind: 'window-show', windowId: opts.id });
         },
         hide(): void {
           if (closed) return;
-          bc.postMessage({ kind: 'window-hide', windowId: opts.id });
+          postRelay({ kind: 'window-hide', windowId: opts.id });
         },
         close(): void {
           if (closed) return;
-          bc.postMessage({ kind: 'window-close', windowId: opts.id });
+          postRelay({ kind: 'window-close', windowId: opts.id });
           // Eagerly drop the registry entry — the relay will eventually emit
           // window-close-event which would also flip `closed`, but removing
           // here keeps registry size accurate from the caller's perspective
@@ -598,7 +603,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
         },
         bringToFront(): void {
           if (closed) return;
-          bc.postMessage({ kind: 'window-bring', windowId: opts.id });
+          postRelay({ kind: 'window-bring', windowId: opts.id });
         },
         setTitle(s: string): void {
           if (closed) return;
@@ -606,7 +611,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
           // RELAY_CHANNEL on its own and updates the title bar on this
           // event (no relay round-trip needed for a pure UI tweak).
           const msg: WindowSetTitleRequest = { kind: 'window-set-title', windowId: opts.id, title: s };
-          bc.postMessage(msg);
+          postRelay(msg as unknown as Record<string, unknown>);
         },
         /** Reflects last-acked window-show-event / window-hide-event from the
          *  relay — NOT real-time native state. If SteamClient.Window calls
@@ -627,7 +632,7 @@ export function makeUiApi(registry: Registry, bridge: Bridge): UiApi {
             nativeWarn('openWindow.postMessage: payload too large', { windowId: opts.id, bytes });
             return;
           }
-          bc.postMessage({ kind: 'window-postMessage', windowId: opts.id, data });
+          postRelay({ kind: 'window-postMessage', windowId: opts.id, data });
         },
         on(event, cb): () => void {
           const set = sets[event];

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -45,6 +45,10 @@ let nextId = 1;
 const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: unknown) => void }>();
 
 export function createBridge(transport?: BridgeTransport): Bridge {
+  const capturedNativeBridge = !transport && typeof window.__sb_native === 'function'
+    ? window.__sb_native
+    : undefined;
+
   window.__sb_resolve = (id: number, resp: BridgeResponse) => {
     const p = pending.get(id);
     if (!p) return;
@@ -57,10 +61,11 @@ export function createBridge(transport?: BridgeTransport): Bridge {
     if (transport) {
       transport.send(payload);
     } else {
-      if (typeof window.__sb_native !== 'function') {
+      const nativeBridge = capturedNativeBridge ?? window.__sb_native;
+      if (typeof nativeBridge !== 'function') {
         throw new Error('native bridge not installed');
       }
-      window.__sb_native(payload);
+      nativeBridge(payload);
     }
   }
 
@@ -104,11 +109,25 @@ export function createBridge(transport?: BridgeTransport): Bridge {
       if (transport) {
         transport.send(envelope);
       } else {
-        if (typeof window.__sb_native !== 'function') {
+        const nativeBridge = capturedNativeBridge ?? window.__sb_native;
+        if (typeof nativeBridge !== 'function') {
           throw new Error('native bridge not installed');
         }
-        window.__sb_native(envelope);
+        nativeBridge(envelope);
       }
     },
   };
+}
+
+export function hideNativeBridgeGlobal(): void {
+  try {
+    Object.defineProperty(window, '__sb_native', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  } catch {
+    // If the native side made the slot non-configurable, the framework cannot
+    // hide it client-side; native authorization must still reject bad calls.
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { createRegistry } from './registry';
-import { createBridge } from './bridge';
+import { createBridge, hideNativeBridgeGlobal } from './bridge';
 import { makeUiApi } from './api/ui';
 import { makeSteamApi } from './api/steam';
 import { makeLifecycleApi } from './api/lifecycle';
@@ -18,14 +18,15 @@ import { startRelay } from './relay/shared-context';
 import { nativeWarn } from './native-warn';
 import { reportUserBinding } from './report-user-binding';
 import { prefetchSetupId } from './prefetch-setup-id';
-import type { SbApi } from './api/api-types';
+import type { PluginRegistrationApi, SbApi } from './api/api-types';
 
 declare const __SB_FRAMEWORK_VERSION__: string;
 declare const __SB_PRODUCTION__: boolean;
 
 declare global {
   interface Window {
-    sb?: SbApi;
+    sb?: PluginRegistrationApi;
+    __sb_framework_teardown?: () => void;
     // __sb_relay_started and __sb_relay_teardown are declared on the Window
     // interface in framework/src/relay/shared-context.ts. We rely on the
     // declaration-merging from the import above so we don't have to
@@ -70,7 +71,7 @@ declare global {
     }
   }
   window.__sb_relay_started = false;
-  if (window.sb) {
+  if (typeof window.__sb_framework_teardown === 'function') {
     // rollbackAll aborts the OLD scope (its own AbortController) and
     // removes DOM mutations from the prior injection (header buttons,
     // popups). Without this, an old button stays in the toolbar but its
@@ -82,10 +83,12 @@ declare global {
     // (called by the freshly-evaluated plugin) to insert a button wired to
     // the live bridge.
     try {
-      window.sb.lifecycle.rollbackAll();
+      window.__sb_framework_teardown();
     } catch (e) {
-      nativeWarn('prior sb.lifecycle.rollbackAll threw', { error: String(e) });
+      nativeWarn('prior __sb_framework_teardown threw', { error: String(e) });
     }
+  }
+  if (window.sb) {
     try {
       // writable:true here so the next defineProperty (line below) can
       // overwrite — even though the prior writable:false locked the slot,
@@ -152,14 +155,28 @@ declare global {
     plugins,
     keys,
   };
+  const registrationApi: PluginRegistrationApi = {
+    version: api.version,
+    get state() { return api.state; },
+    plugins,
+  };
 
-  // writable:false (vs the writable:true on the temporary clear above) is
-  // intentional — the prior clear is a transient unset, the final assign
-  // is the real shape and we don't want a curious plugin reassigning it.
-  // configurable:true preserves hot-reinject-ability (we redefine on next
-  // bootstrap). Not a security boundary — gate is the Ed25519 manifest
-  // signature, this is just casual defense against accidental overwrite.
-  Object.defineProperty(window, 'sb', { value: api, writable: false, configurable: true });
+  const frameworkTeardown = (): void => {
+    lifecycle.rollbackAll();
+    if (window.__sb_framework_teardown === frameworkTeardown) {
+      window.__sb_framework_teardown = undefined;
+    }
+  };
+  Object.defineProperty(window, '__sb_framework_teardown', {
+    value: frameworkTeardown,
+    writable: false,
+    configurable: true,
+  });
+
+  // Only the registration facade is global. The privileged API is passed to
+  // plugin init through a capability-gated PluginContext after manifest
+  // validation, so plugin code cannot bypass capabilities via window.sb.
+  Object.defineProperty(window, 'sb', { value: registrationApi, writable: false, configurable: true });
 
   // Global error / unhandled-rejection forwarders. Routed through scope.listen
   // so they auto-detach on rollbackAll — without that, the OLD injection's
@@ -213,6 +230,7 @@ declare global {
 
   reportUserBinding(steam, bridge);
   prefetchSetupId(api.app, window as { __SB_BOOSTER_UUID__?: string });
+  hideNativeBridgeGlobal();
 })();
 
 // Re-export the public API surface so the npm entry (dist/index.js ESM +

--- a/src/navigation-safety.ts
+++ b/src/navigation-safety.ts
@@ -1,0 +1,24 @@
+// Shared navigation safety checks used by public APIs and relay sinks.
+// The relay must validate again because callers can bypass public API helpers.
+
+/** @internal */
+export function isUrlSafeForNavigation(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  if (parsed.username !== '' || parsed.password !== '') return false;
+  if (parsed.port !== '') return false;
+  return true;
+}
+
+export function safeHostForLog(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return '<malformed>';
+  }
+}

--- a/src/plugins/bootstrap.ts
+++ b/src/plugins/bootstrap.ts
@@ -212,9 +212,13 @@ export async function drainPluginsOnReady(args: DrainPluginsArgs): Promise<Plugi
     // for their per-plugin wrappers (topic-prefix-enforced bus, id-auto-
     // prefixed ui) so plugins can't fire bus events outside their namespace
     // or collide DOM ids with other plugins.
+    const pluginConfigs = granted.has(Capability.Configs)
+      ? createPluginConfigs(bridge, bundle.id)
+      : (undefined as never);
     const gated = buildGatedSb(realSb, granted);
     const finalSb: SbApi = {
       ...gated,
+      configs: pluginConfigs,
       bus: granted.has(Capability.Bus)
         ? createPluginBus(realSb.bus, bundle.id, pluginScope.signal)
         : (undefined as never),
@@ -230,9 +234,7 @@ export async function drainPluginsOnReady(args: DrainPluginsArgs): Promise<Plugi
       granted,
       sb: finalSb,
       scope: pluginScope,
-      configs: granted.has(Capability.Configs)
-        ? createPluginConfigs(bridge, bundle.id)
-        : (undefined as never),
+      configs: pluginConfigs,
       log: createPluginLog(bundle.id, (op, pid, args2) => bridge.notify(op, pid, args2 as object)),
       signal: pluginScope.signal,
     };

--- a/src/relay/auth.ts
+++ b/src/relay/auth.ts
@@ -1,0 +1,25 @@
+declare global {
+  var __SB_RELAY_TOKEN__: string | undefined;
+}
+
+export const RELAY_AUTH_FIELD = '__sbRelayToken';
+
+export type RelayAuthToken = string | undefined;
+
+export function readRelayAuthToken(): RelayAuthToken {
+  const token = globalThis.__SB_RELAY_TOKEN__;
+  return typeof token === 'string' && token.length >= 32 ? token : undefined;
+}
+
+export function withRelayAuth<T extends Record<string, unknown>>(
+  msg: T,
+  token: RelayAuthToken,
+): T {
+  return token ? { ...msg, [RELAY_AUTH_FIELD]: token } : msg;
+}
+
+export function hasValidRelayAuth(msg: unknown, token: RelayAuthToken): boolean {
+  if (!token) return true;
+  if (!msg || typeof msg !== 'object') return false;
+  return (msg as Record<string, unknown>)[RELAY_AUTH_FIELD] === token;
+}

--- a/src/relay/popup-factory.ts
+++ b/src/relay/popup-factory.ts
@@ -13,6 +13,7 @@ import type {
   SteamPopupConstructor,
 } from './popup-types';
 import { composeWrapperHtml } from './window-wrapper';
+import type { RelayAuthToken } from './auth';
 
 interface PopupTemplate {
   Ctor: SteamPopupConstructor;
@@ -127,6 +128,7 @@ interface CreateSteamWindowArgs {
   centerOnMain: boolean;
   iframeBackground?: string;
   embedOrigins?: string[];
+  relayAuthToken?: RelayAuthToken;
 }
 
 export function createSteamWindow(args: CreateSteamWindowArgs):
@@ -146,6 +148,7 @@ export function createSteamWindow(args: CreateSteamWindowArgs):
     content:  args.content,
     iframeBackground: args.iframeBackground,
     embedOrigins: args.embedOrigins,
+    relayAuthToken: args.relayAuthToken,
   });
 
   // Compute centered position UPFRONT so the popup opens already-centered

--- a/src/relay/shared-context.ts
+++ b/src/relay/shared-context.ts
@@ -25,9 +25,11 @@ import { destroyPopup } from './popup-lifecycle';
 import type { SteamPopupParams } from './popup-types';
 import { makeWindowHandlers, type WindowTracking } from './window-handlers';
 import { setupExternalWindowRelay, teardownExternalWindowRelay } from './external-window';
-import { createBridge } from '../bridge';
+import { createBridge, hideNativeBridgeGlobal } from '../bridge';
 import { handleActivateProductKey } from './key-activation';
 import { handleGetMachineId } from './machine-id';
+import { isUrlSafeForNavigation, safeHostForLog } from '../navigation-safety';
+import { hasValidRelayAuth, readRelayAuthToken } from './auth';
 
 declare global {
   interface SteamClientShape {
@@ -201,6 +203,7 @@ export function startRelay(scope: ScopeApi): () => void {
   window.__sb_relay_teardown = initialTeardown;
 
   const bc = new BroadcastChannel(RELAY_CHANNEL);
+  const relayAuthToken = readRelayAuthToken();
   // Singleton map keyed by popupId. Re-attach with the same id reuses the
   // existing native window — refusing to allocate a second native popup is
   // the *whole point* of the attach-once / toggle-many model. Spawning a
@@ -210,7 +213,7 @@ export function startRelay(scope: ScopeApi): () => void {
   // Per-window tracking — shared with makeWindowHandlers so attach-popup's
   // idTaken can also see open windows (single-namespace: one id at a time).
   const windows = new Map<string, WindowTracking>();
-  const winHandlers = makeWindowHandlers({ bc, scope, popups, windows });
+  const winHandlers = makeWindowHandlers({ bc, scope, popups, windows, relayAuthToken });
   // Set when teardown begins so a microtask-deferred attach (see
   // handleAttachPopup) skips its setup if the relay is being torn down.
   // Without this, an attach in flight at teardown time would create an
@@ -220,6 +223,7 @@ export function startRelay(scope: ScopeApi): () => void {
   scope.listen<MessageEvent>(bc, 'message', (ev) => {
     const msg = ev.data as RelayMessage;
     if (!msg || typeof msg !== 'object') return;
+    if (!hasValidRelayAuth(msg, relayAuthToken)) return;
     switch (msg.kind) {
       case 'attach-popup':
         handleAttachPopup(msg);
@@ -288,6 +292,7 @@ export function startRelay(scope: ScopeApi): () => void {
   // multiple createBridge() calls are functionally idempotent.
   //
   const relayBridge = createBridge();
+  hideNativeBridgeGlobal();
 
   // Wire external-window relay: subscribes to MWBM store changes and
   // handles open/setUrl/close/native-title BC messages from main shell.
@@ -611,6 +616,14 @@ export function startRelay(scope: ScopeApi): () => void {
 
   function handleNavigate(msg: NavigateRequest): void {
     try {
+      if (typeof msg.url !== 'string' || msg.url.length > 2048 || !isUrlSafeForNavigation(msg.url)) {
+        bc.postMessage({
+          kind: 'navigate-error',
+          requestId: msg.requestId,
+          error: `url failed safety check: ${safeHostForLog(String(msg.url))}`,
+        });
+        return;
+      }
       if (!window.MainWindowBrowserManager?.LoadURL) {
         bc.postMessage({
           kind: 'navigate-error',

--- a/src/relay/window-handlers.ts
+++ b/src/relay/window-handlers.ts
@@ -18,6 +18,7 @@ import type {
 import { createSteamWindow } from './popup-factory';
 import { destroyPopup } from './popup-lifecycle';
 import type { SteamPopupInstance, SteamPopupWindow } from './popup-types';
+import type { RelayAuthToken } from './auth';
 
 // Width/height clamps — caller-supplied values outside [200..2000] x
 // [150..1500] get squished into range. Mirror of framework-side ui.ts
@@ -98,8 +99,9 @@ export function makeWindowHandlers(args: {
   scope: ScopeLike;
   popups: Map<string, unknown>;
   windows: Map<string, WindowTracking>;
+  relayAuthToken?: RelayAuthToken;
 }) {
-  const { bc, scope, popups, windows } = args;
+  const { bc, scope, popups, windows, relayAuthToken } = args;
 
   // Defense-in-depth: an id is "taken" if EITHER an active attachPopup
   // OR another open-window already owns it. Matches the framework-side
@@ -178,6 +180,7 @@ export function makeWindowHandlers(args: {
       centerOnMain: req.centerOnMain,
       iframeBackground: req.iframeBackground,
       embedOrigins,
+      relayAuthToken,
     });
 
     if (!created) return rejectOpen(req, 'createSteamWindow returned null');

--- a/src/relay/window-wrapper.ts
+++ b/src/relay/window-wrapper.ts
@@ -4,6 +4,7 @@
 
 import { RELAY_CHANNEL, WINDOW_MESSAGE_MAX_BYTES } from './protocol';
 import { LL } from '../i18n';
+import { RELAY_AUTH_FIELD, type RelayAuthToken } from './auth';
 // Static wrapper chrome. Single source of truth is the .css; dev/tests read it
 // raw via the `type: 'text'` import, production injects a minified copy through
 // the `__SB_WRAPPER_CSS__` bun define (see build.ts → loadCss), which folds the
@@ -38,6 +39,7 @@ export interface WrapperArgs {
   /** Allowlist дополнительных origin'ов (помимо origin стартового url),
    *  которым обёртка отвечает на sb:ready. Default = [FRAME_ORIGIN]. */
   embedOrigins?: string[];
+  relayAuthToken?: RelayAuthToken;
 }
 
 function escapeHtmlAttr(s: string): string {
@@ -126,6 +128,8 @@ export function composeWrapperHtml(args: WrapperArgs): string {
   const frameOriginLiteral  = JSON.stringify(frameOrigin);
   const embedOriginsLiteral = JSON.stringify(embedOrigins);
   const appVersionLiteral   = JSON.stringify(APP_VERSION);
+  const relayAuthFieldLiteral = JSON.stringify(RELAY_AUTH_FIELD);
+  const relayAuthTokenLiteral = JSON.stringify(args.relayAuthToken);
   const MSG_CAP = WINDOW_MESSAGE_MAX_BYTES;
   const acceptLiteral = acceptFrameMessage.toString();
 
@@ -152,11 +156,17 @@ export function composeWrapperHtml(args: WrapperArgs): string {
     const FRAME_ORIGIN = ${frameOriginLiteral};
     const EMBED_ORIGINS = ${embedOriginsLiteral};
     const APP_VERSION = ${appVersionLiteral};
+    const RELAY_AUTH_FIELD = ${relayAuthFieldLiteral};
+    const RELAY_AUTH_TOKEN = ${relayAuthTokenLiteral};
     const MSG_CAP = ${MSG_CAP};
     const sbBC = new BroadcastChannel(${channelLiteral});
     const frame = document.getElementById('booster-win-frame');
+    function relayMsg(m) {
+      if (RELAY_AUTH_TOKEN) m[RELAY_AUTH_FIELD] = RELAY_AUTH_TOKEN;
+      return m;
+    }
     document.getElementById('booster-win-close').addEventListener('click', () => {
-      try { sbBC.postMessage({ kind:'window-user-close', windowId: POPUP_ID }); } catch (e) {}
+      try { sbBC.postMessage(relayMsg({ kind:'window-user-close', windowId: POPUP_ID })); } catch (e) {}
       try { window.SteamClient.Window.Close(); } catch (e) {}
     });
     function buildEmbed() {
@@ -185,7 +195,7 @@ export function composeWrapperHtml(args: WrapperArgs): string {
       // асимметрия с outbound (UTF-8 байты в ui.ts); оба ~16 КБ, точная
       // мера не критична, это backstop против флуда.
       try { if (JSON.stringify(d).length > MSG_CAP) return; } catch (er) { return; }
-      try { sbBC.postMessage({ kind:'window-message', windowId: POPUP_ID, data: d }); } catch (er) {}
+      try { sbBC.postMessage(relayMsg({ kind:'window-message', windowId: POPUP_ID, data: d })); } catch (er) {}
     }
     window.addEventListener('message', onFrameMsg);
     const handleBc = ${handleWrapperBcMessage.toString()};

--- a/tests/bridge.test.ts
+++ b/tests/bridge.test.ts
@@ -5,7 +5,7 @@ import { test, expect } from 'bun:test';
 // @ts-expect-error
 globalThis.window = globalThis;
 
-import { createBridge } from '../src/bridge';
+import { createBridge, hideNativeBridgeGlobal } from '../src/bridge';
 
 test('bridge sends payload via __sb_native and resolves on __sb_resolve', async () => {
   const bridge = createBridge();
@@ -32,8 +32,8 @@ test('bridge rejects on response.ok=false', async () => {
 });
 
 test('bridge rejects if __sb_native not installed', async () => {
-  const bridge = createBridge();
   delete window.__sb_native;
+  const bridge = createBridge();
   await expect(bridge.call('foo')).rejects.toThrow('native bridge not installed');
 });
 
@@ -106,4 +106,18 @@ test('call without pluginId opt omits pluginId field', () => {
   expect(sent).toHaveLength(1);
   const env = JSON.parse(sent[0]);
   expect(env.pluginId).toBeUndefined();
+});
+
+test('bridge can keep using captured native callback after __sb_native is hidden', async () => {
+  let lastSent: any = null;
+  window.__sb_native = (s: string) => { lastSent = JSON.parse(s); };
+  const bridge = createBridge();
+
+  hideNativeBridgeGlobal();
+  expect(window.__sb_native).toBeUndefined();
+
+  const p = bridge.call('after_hide', {});
+  expect(lastSent.op).toBe('after_hide');
+  window.__sb_resolve!(lastSent.requestId, { ok: true, result: { ok: true } });
+  await expect(p).resolves.toEqual({ ok: true });
 });

--- a/tests/plugins-bootstrap.test.ts
+++ b/tests/plugins-bootstrap.test.ts
@@ -363,6 +363,38 @@ test('drainPluginsOnReady wraps bus with topic-prefix enforcement', async () => 
   expect(busPublishThrew).toBe(true);
 });
 
+test('drainPluginsOnReady uses per-plugin configs for ctx.configs and ctx.sb.configs', async () => {
+  let sameConfigObject = false;
+  const bundle = makeBundle({
+    capabilities: [Capability.Configs],
+    init: async (ctx) => {
+      sameConfigObject = ctx.sb.configs === ctx.configs;
+      await ctx.sb.configs.write('settings', { enabled: true });
+      await ctx.configs.read('settings');
+    },
+  });
+  registry.add(bundle);
+  const manifest: PluginsManifestPrefix = {
+    injectorVersion: 'test', contextKind: ContextKind.Main, userDisabledPlugins: [],
+    plugins: [{
+      id: 'booster-test', version: '1.0.0', apiVersion: 1,
+      contextKinds: [ContextKind.Main],
+      grantedCapabilities: [Capability.Configs],
+    }],
+  };
+
+  await drainPluginsOnReady({
+    registry, manifest, realSb: sb, bridge,
+    currentUrl: 'https://example.com/',
+  });
+
+  expect(sameConfigObject).toBe(true);
+  expect(bridge.calls).toEqual([
+    { op: 'config_write', args: { name: 'settings', data: { enabled: true } }, opts: { pluginId: 'booster-test' } },
+    { op: 'config_read', args: { name: 'settings' }, opts: { pluginId: 'booster-test' } },
+  ]);
+});
+
 test('drainPluginsOnReady stashes outcomes on realSb._pluginOutcomes', async () => {
   const bundle = makeBundle({ init: () => () => { /* cleanup */ } });
   registry.add(bundle);

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -171,6 +171,7 @@ afterEach(() => {
     stopRelay();
     stopRelay = null;
   }
+  delete (globalThis as { __SB_RELAY_TOKEN__?: string }).__SB_RELAY_TOKEN__;
 });
 
 test('relay handles navigate request → MWBM.LoadURL + navigate-done reply', async () => {
@@ -199,6 +200,69 @@ test('relay handles navigate request → MWBM.LoadURL + navigate-done reply', as
     replies.find((r) => r.kind === 'navigate-done' && r.requestId === 7),
   ).toBeTruthy();
   sender.close();
+});
+
+test('relay rejects unsafe navigate URL before MWBM.LoadURL', async () => {
+  let loadedUrl = '';
+  const mwbm = { LoadURL: (u: string) => { loadedUrl = u; } };
+  // @ts-expect-error
+  globalThis.MainWindowBrowserManager = mwbm;
+  (win as unknown as { MainWindowBrowserManager: unknown }).MainWindowBrowserManager = mwbm;
+
+  const { startRelay } = await import('../src/relay/shared-context');
+  stopRelay = startRelay(createScope());
+
+  const sender = new BroadcastChannel(RELAY_CHANNEL);
+  const replies: Array<Record<string, unknown>> = [];
+  sender.addEventListener('message', (e: MessageEvent) => {
+    replies.push(e.data as Record<string, unknown>);
+  });
+
+  sender.postMessage({ kind: 'navigate', requestId: 70, url: 'javascript:alert(1)' });
+  await flushBC();
+
+  expect(loadedUrl).toBe('');
+  const err = replies.find((r) => r.kind === 'navigate-error' && r.requestId === 70);
+  expect(err).toBeTruthy();
+  expect((err as { error: string }).error).toContain('url failed safety check');
+  sender.close();
+});
+
+test('relay ignores unauthenticated commands when __SB_RELAY_TOKEN__ is present', async () => {
+  const token = 'x'.repeat(32);
+  (globalThis as { __SB_RELAY_TOKEN__?: string }).__SB_RELAY_TOKEN__ = token;
+  let loadedUrl = '';
+  const mwbm = { LoadURL: (u: string) => { loadedUrl = u; } };
+  // @ts-expect-error
+  globalThis.MainWindowBrowserManager = mwbm;
+  (win as unknown as { MainWindowBrowserManager: unknown }).MainWindowBrowserManager = mwbm;
+
+  const { startRelay } = await import('../src/relay/shared-context');
+  stopRelay = startRelay(createScope());
+
+  const sender = new BroadcastChannel(RELAY_CHANNEL);
+  const replies: Array<Record<string, unknown>> = [];
+  sender.addEventListener('message', (e: MessageEvent) => {
+    replies.push(e.data as Record<string, unknown>);
+  });
+
+  sender.postMessage({ kind: 'navigate', requestId: 71, url: 'https://steambalance.cc/pay/abc' });
+  await flushBC();
+  expect(loadedUrl).toBe('');
+  expect(replies.find((r) => r.requestId === 71)).toBeUndefined();
+
+  sender.postMessage({
+    kind: 'navigate',
+    requestId: 72,
+    url: 'https://steambalance.cc/pay/abc',
+    __sbRelayToken: token,
+  });
+  await flushBC();
+  expect(loadedUrl).toBe('https://steambalance.cc/pay/abc');
+  expect(replies.find((r) => r.kind === 'navigate-done' && r.requestId === 72)).toBeTruthy();
+
+  sender.close();
+  delete (globalThis as { __SB_RELAY_TOKEN__?: string }).__SB_RELAY_TOKEN__;
 });
 
 test('relay handles attach-popup → constructs Popup with chromeless flags + writes html + reply', async () => {


### PR DESCRIPTION
## Что меняется

Этот PR закрывает несколько проблем в security-boundary для плагинов SteamBooster.

Основной риск был в том, что модель capabilities выглядела как ограничение прав, но плагин мог обойти её через глобальный `window.sb` или через общий relay-канал `BroadcastChannel('sb_cmd')`. В таком виде стороннему плагину нельзя было безопасно доверять даже если в manifest ему выданы ограниченные capabilities.

## Основные исправления

- `window.sb` теперь остаётся только registration facade: `version`, `state`, `plugins.register/ready`.
- Привилегированный API теперь доступен плагину только через `PluginContext.sb` после manifest validation и capability intersection.
- `ctx.sb.configs` теперь использует тот же per-plugin wrapper, что и `ctx.configs`, с auto-injected `pluginId`.
- URL validation вынесена в общий helper и применяется не только в public API, но и relay-side прямо перед `MainWindowBrowserManager.LoadURL`.
- Добавлена relay-auth схема через `__SB_RELAY_TOKEN__`: если native loader инжектит токен, relay игнорирует команды без токена.
- Popup wrapper/openWindow pipeline тоже прокидывает relay token, чтобы safe-mode не ломал штатные window events.
- Bridge захватывает native callback в closure и после bootstrap прячет глобальный `window.__sb_native`, чтобы плагину было сложнее дергать native bridge напрямую.
- Добавлены regression tests на обходы capability/configs, unsafe relay navigation, relay token и hidden native bridge.
- Добавлена документация `docs/security-hardening.md` с native-side requirements.

## Почему это важно

Без этих правок permission model не была полноценной security boundary: ограниченный плагин мог попробовать получить доступ к privileged действиям напрямую, в обход gated `ctx.sb`.

После этого PR framework-side boundary становится заметно жёстче. При этом для полного production-hardening всё ещё нужна парная правка в native injector: он должен генерировать high-entropy `__SB_RELAY_TOKEN__` на запуск и инжектить его во все JS contexts до загрузки framework.

## Проверка

Прогнано локально:

```bash
npx tsc --noEmit
npx --yes bun@latest test tests/bridge.test.ts tests/relay.test.ts tests/plugins-bootstrap.test.ts tests/steam-api.test.ts tests/window-wrapper.test.ts
npx --yes bun@latest run build
```

Результат focused security/API tests: `112 pass, 0 fail`.

Также запускался полный `bun test`: `577 pass`, `23 skip`, `1 fail`. Единственный fail не связан с изменениями: `tests/build-watch.test.ts` внутри теста запускает `bun` из системного PATH, а в текущем Windows окружении Bun не установлен глобально. Через `npx --yes bun@latest` build и focused tests проходят.

## Важное ограничение

Этот PR исправляет framework-side часть. Для полного закрытия relay boundary нужен native-side follow-up:

1. Генерировать свежий случайный token на процесс/сессию.
2. Инжектить `globalThis.__SB_RELAY_TOKEN__ = "..."` в MainShell и SharedJSContext до framework.
3. Не писать token в logs/config/manifest/public API.
4. По возможности не доверять `pluginId`, пришедшему из JS, а привязывать privileged native ops к реальному plugin execution context.
