### PR TITLE
fix: harden plugin capability boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ build/
 
 # Logs
 *.log
+.env
+.env.*
+!.env.example
 
 # OS
 Thumbs.db

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { startRelay } from './relay/shared-context';
 import { nativeWarn } from './native-warn';
 import { reportUserBinding } from './report-user-binding';
 import { prefetchSetupId } from './prefetch-setup-id';
+import { buildGlobalSb, type GlobalSbApi } from './plugins/capability-gating';
 import type { SbApi } from './api/api-types';
 
 declare const __SB_FRAMEWORK_VERSION__: string;
@@ -25,7 +26,8 @@ declare const __SB_PRODUCTION__: boolean;
 
 declare global {
   interface Window {
-    sb?: SbApi;
+    sb?: GlobalSbApi;
+    __sb_framework_rollback?: () => void;
     // __sb_relay_started and __sb_relay_teardown are declared on the Window
     // interface in framework/src/relay/shared-context.ts. We rely on the
     // declaration-merging from the import above so we don't have to
@@ -70,7 +72,12 @@ declare global {
     }
   }
   window.__sb_relay_started = false;
-  if (window.sb) {
+  const priorRollback =
+    typeof window.__sb_framework_rollback === 'function'
+      ? window.__sb_framework_rollback
+      : (window.sb as unknown as { lifecycle?: { rollbackAll?: () => void } } | undefined)
+          ?.lifecycle?.rollbackAll;
+  if (priorRollback) {
     // rollbackAll aborts the OLD scope (its own AbortController) and
     // removes DOM mutations from the prior injection (header buttons,
     // popups). Without this, an old button stays in the toolbar but its
@@ -82,7 +89,7 @@ declare global {
     // (called by the freshly-evaluated plugin) to insert a button wired to
     // the live bridge.
     try {
-      window.sb.lifecycle.rollbackAll();
+      priorRollback();
     } catch (e) {
       nativeWarn('prior sb.lifecycle.rollbackAll threw', { error: String(e) });
     }
@@ -94,6 +101,20 @@ declare global {
     } catch {
       // configurable was false on a prior injection (shouldn't happen, but safe-guard)
     }
+  }
+  try {
+    Object.defineProperty(window, 'sb', { value: undefined, writable: true, configurable: true });
+  } catch {
+    // configurable was false on a prior injection (shouldn't happen, but safe-guard)
+  }
+  try {
+    Object.defineProperty(window, '__sb_framework_rollback', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  } catch {
+    // best-effort hot-reinject cleanup
   }
 
   if (isSharedContext) {
@@ -159,7 +180,12 @@ declare global {
   // configurable:true preserves hot-reinject-ability (we redefine on next
   // bootstrap). Not a security boundary — gate is the Ed25519 manifest
   // signature, this is just casual defense against accidental overwrite.
-  Object.defineProperty(window, 'sb', { value: api, writable: false, configurable: true });
+  Object.defineProperty(window, 'sb', { value: buildGlobalSb(api), writable: false, configurable: true });
+  Object.defineProperty(window, '__sb_framework_rollback', {
+    value: () => { lifecycle.rollbackAll(); },
+    writable: false,
+    configurable: true,
+  });
 
   // Global error / unhandled-rejection forwarders. Routed through scope.listen
   // so they auto-detach on rollbackAll — without that, the OLD injection's

--- a/src/plugins/capability-gating.ts
+++ b/src/plugins/capability-gating.ts
@@ -3,6 +3,20 @@ import {
   type SbApi,
 } from '../api/api-types';
 
+export interface GlobalSbApi {
+  readonly version: SbApi['version'];
+  readonly state: SbApi['state'];
+  readonly plugins: SbApi['plugins'];
+}
+
+export function buildGlobalSb(real: SbApi): GlobalSbApi {
+  return {
+    version: real.version,
+    get state() { return real.state; },
+    plugins: real.plugins,
+  };
+}
+
 /**
  * Build a capability-gated view of the framework's SbApi for plugin use.
  *

--- a/src/relay/shared-context.ts
+++ b/src/relay/shared-context.ts
@@ -28,6 +28,7 @@ import { setupExternalWindowRelay, teardownExternalWindowRelay } from './externa
 import { createBridge } from '../bridge';
 import { handleActivateProductKey } from './key-activation';
 import { handleGetMachineId } from './machine-id';
+import { isUrlSafeForNavigation } from '../api/steam';
 
 declare global {
   interface SteamClientShape {
@@ -611,6 +612,14 @@ export function startRelay(scope: ScopeApi): () => void {
 
   function handleNavigate(msg: NavigateRequest): void {
     try {
+      if (!isUrlSafeForNavigation(msg.url)) {
+        bc.postMessage({
+          kind: 'navigate-error',
+          requestId: msg.requestId,
+          error: 'unsafe url',
+        });
+        return;
+      }
       if (!window.MainWindowBrowserManager?.LoadURL) {
         bc.postMessage({
           kind: 'navigate-error',

--- a/tests/plugins-capability-gating.test.ts
+++ b/tests/plugins-capability-gating.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'bun:test';
-import { buildGatedSb } from '../src/plugins/capability-gating';
+import { buildGatedSb, buildGlobalSb } from '../src/plugins/capability-gating';
 import { Capability, type SbApi } from '../src/api/api-types';
 
 // Minimal mock SbApi for testing.
@@ -65,4 +65,21 @@ test('buildGatedSb exposes keys when granted', () => {
 test('buildGatedSb hides keys when not granted', () => {
   const realSb = { keys: {} } as any;
   expect(buildGatedSb(realSb, new Set()).keys).toBeUndefined();
+});
+
+test('buildGlobalSb exposes only plugin registration surface', () => {
+  const real = makeMockSb();
+  const globalSb = buildGlobalSb(real) as unknown as Record<string, unknown>;
+
+  expect(globalSb.version).toBe(real.version);
+  expect(globalSb.state).toBe(real.state);
+  expect(globalSb.plugins).toBe(real.plugins);
+  expect(globalSb.lifecycle).toBeUndefined();
+  expect(globalSb.scope).toBeUndefined();
+  expect(globalSb.ui).toBeUndefined();
+  expect(globalSb.steam).toBeUndefined();
+  expect(globalSb.configs).toBeUndefined();
+  expect(globalSb.bus).toBeUndefined();
+  expect(globalSb.pages).toBeUndefined();
+  expect(globalSb.keys).toBeUndefined();
 });

--- a/tests/relay.test.ts
+++ b/tests/relay.test.ts
@@ -201,6 +201,37 @@ test('relay handles navigate request → MWBM.LoadURL + navigate-done reply', as
   sender.close();
 });
 
+test('relay rejects unsafe navigate urls before LoadURL', async () => {
+  let loadedUrl = '';
+  const mwbm = { LoadURL: (u: string) => { loadedUrl = u; } };
+  // @ts-expect-error
+  globalThis.MainWindowBrowserManager = mwbm;
+  (win as unknown as { MainWindowBrowserManager: unknown }).MainWindowBrowserManager = mwbm;
+
+  const { startRelay } = await import('../src/relay/shared-context');
+  stopRelay = startRelay(createScope());
+
+  const sender = new BroadcastChannel(RELAY_CHANNEL);
+  const replies: Array<Record<string, unknown>> = [];
+  sender.addEventListener('message', (e: MessageEvent) => {
+    replies.push(e.data as Record<string, unknown>);
+  });
+
+  for (const [i, url] of [
+    'javascript:alert(1)',
+    'http://steambalance.cc/x',
+    'https://user:pass@steambalance.cc/x',
+    'https://steambalance.cc:8443/x',
+  ].entries()) {
+    sender.postMessage({ kind: 'navigate', requestId: 70 + i, url });
+    await flushBC();
+  }
+
+  expect(loadedUrl).toBe('');
+  expect(replies.filter((r) => r.kind === 'navigate-error').length).toBe(4);
+  sender.close();
+});
+
 test('relay handles attach-popup → constructs Popup with chromeless flags + writes html + reply', async () => {
   const cap = newCapture();
   installPopupManagerMock({ capture: cap });


### PR DESCRIPTION
﻿## Summary
- expose only the plugin registration facade on `window.sb`
- keep privileged APIs available through capability-gated `ctx.sb`
- reject unsafe relay navigate URLs before `MainWindowBrowserManager.LoadURL`
- ignore local env files

## Checks
- `bun install --registry https://registry.npmjs.org`
- `bun test`
- `bun run build`
- `git diff --check`
